### PR TITLE
introduce flist.FIELD notation and interactive field name lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,24 @@ Set some scalar data on the flist:
     f['PIN_FLD_STATUS'] = 1
     f['PIN_FLD_CREATED_T'] = datetime.now()  # you can also set it to an integer
 
+Or if you prefer `flist.FIELD` notation:
+
+    f.PIN_FLD_POID = '/account'  # type /account, id -1, revision 0
+    f.PIN_FLD_STATUS = 1
+    f.PIN_FLD_CREATED_T = datetime.now()  # you can also set it to an integer
+
 Create a substructure in one shot, the preferred way:
 
     f['PIN_FLD_INHERITED_INFO'] = {
         'PIN_FLD_POID': ('/service', 1234), # type service, id 1234, revision 0
         'PIN_FLD_STATUS': 2,
     }
+
+Or if you prefer `flist.FIELD` notation:
+
+    f.PIN_FLD_INHERITED_INFO = {}
+    f.PIN_FLD_INHERITED_INFO.PIN_FLD_POID = ('/service', 1234) # type service, id 1234, revision 0
+    f.PIN_FLD_INHERITED_INFO.PIN_FLD_STATUS = 2
 
 Print the flist:
 
@@ -58,6 +70,15 @@ You can also build up a substruct it up piece by piece:
     # You can pull a subsctruct out into its own variable if you like
     substruct = f['PIN_FLD_EVENT']
     substruct['PIN_FLD_STATUS'] = 3
+
+which is equivalent to:
+
+    f.PIN_FLD_EVENT = {}
+    f.PIN_FLD_EVENT.PIN_FLD_POID = ('/service', 1234, 1)  # type service, id 1234, revision 1
+
+    # You can pull a subsctruct out into its own variable if you like
+    substruct = f.PIN_FLD_EVENT
+    substruct.PIN_FLD_STATUS = 3
 
 Let's print it again:
 
@@ -105,6 +126,12 @@ You can instead use list syntax `[]`, and not specify the elem_ids. This will au
         {'PIN_FLD_STATUS': 7},  # sets at elem_id 1 
     ]
 
+or
+
+    f.PIN_FLD_RESULTS = [{}, {}]
+    f.PIN_FLD_RESULTS[0].PIN_FLD_STATUS = 6
+    f.PIN_FLD_RESULTS[1].PIN_FLD_STATUS = 7
+
 Let's print it again:
 
     >>> print(f)
@@ -136,6 +163,17 @@ You can also build up an array piece by piece:
     array = f['PIN_FLD_VALUES']
     array[1] = {}  # Create empty flist on the 1st elem_id of this array
     array[1]['PIN_FLD_STATUS'] = 9  # set one field on the flist we just created
+
+alternatively:
+
+    f.PIN_FLD_VALUES = {}  #  Creates an empty array
+    f.PIN_FLD_VALUES[0] = {'PIN_FLD_STATUS': 8}  # Adds an flist on the 0th elem_id of this array
+
+    # You can pull an array out into its own variable if you like
+    array = f.PIN_FLD_VALUES
+    array[1] = {}  # Create empty flist on the 1st elem_id of this array
+    array[1].PIN_FLD_STATUS = 9  # set one field on the flist we just created
+
 
 Let's print it again:
 
@@ -217,7 +255,7 @@ Get some data off the flist:
     status = f['PIN_FLD_STATUS']
     assert status == 1
     
-    poid = f['PIN_FLD_POID']
+    poid = f.PIN_FLD_POID
     assert poid.type == '/account'
     assert poid.id == -1
     assert poid.revision == 0
@@ -225,7 +263,7 @@ Get some data off the flist:
     
     assert f['PIN_FLD_INHERITED_INFO']['PIN_FLD_POID'].type == '/service'
     assert len(f['PIN_FLD_VALUES']) == 2
-    assert f['PIN_FLD_VALUES'][0]['PIN_FLD_STATUS'] == 8
+    assert f.PIN_FLD_VALUES[0].PIN_FLD_STATUS == 8
 
 Get the length:
 
@@ -237,9 +275,9 @@ Get the length:
     assert len(f['PIN_FLD_INHERITED_INFO']) == 2  # count of a substruct
     assert f['PIN_FLD_INHERITED_INFO'].count() == 2 # same as len
     
-    assert len(f['PIN_FLD_VALUES']) == 2  # count of an array
-    assert f['PIN_FLD_VALUES'].count() == 2  # same as len
     
+    assert len(f.PIN_FLD_VALUES) == 2  # count of an array
+    assert f.PIN_FLD_VALUES.count() == 2  # same as len
 
 Get all the field names:
 
@@ -260,13 +298,13 @@ Check if a field exists on our flist:
 Get an flist at a particular elem_id from an array:
 
     child = f['PIN_FLD_VALUES'][0]
-    child = f['PIN_FLD_VALUES'][1]
+    child = f.PIN_FLD_VALUES[1]
 
 Get any flist from an array (PIN_ELEMID_ANY):
 
     child = f['PIN_FLD_VALUES']['*']
     # This is equivalent
-    child = f['PIN_FLD_VALUES']['PIN_ELEMID_ANY']
+    child = f.PIN_FLD_VALUES['PIN_ELEMID_ANY']
     # This is also equivalent
     child = f['PIN_FLD_VALUES'][-1]
 
@@ -275,6 +313,10 @@ Delete a field:
     assert 'PIN_FLD_STATUS' in f
     del f['PIN_FLD_STATUS']
     assert 'PIN_FLD_STATUS' not in f
+
+    assert 'PIN_FLD_VALUES' in f
+    del f.PIN_FLD_VALUES
+    assert 'PIN_FLD_VALUES' not in f
 
 # Searching Shortcuts for PCM_OP_SEARCH
 

--- a/pybrm/pybrm.py
+++ b/pybrm/pybrm.py
@@ -512,6 +512,7 @@ class Client:
 
 
 class FList:
+    __slots__ = ['client', '_flist', '_virtual_arrays']
     """
     Wrapper for a BRM flist
     To instantiate, call `client.flist()`; do not call `FList()` directly

--- a/pybrm/pybrm.py
+++ b/pybrm/pybrm.py
@@ -1219,6 +1219,9 @@ class FList:
     def __iter__(self):
         yield from self._flist.init_iter()
 
+    def __dir__(self):
+        return super().__dir__() + list(self.keys())
+
     def items(self):
         """Returns the (key, values) of this flist"""
         for name in self:

--- a/pybrm/pybrm.py
+++ b/pybrm/pybrm.py
@@ -715,6 +715,13 @@ class FList:
         """Get a value from this flist by field_name"""
         return self._get_field(item)
 
+    def __getattr__(self, name):
+        """Get a field value from this flist by field_name"""
+        try:
+            return self._get_field(name)
+        except KeyError as ex:
+            raise AttributeError
+
     def get(self, name, default=None):
         """
         Get the value of a field off an flist.
@@ -811,6 +818,15 @@ class FList:
     def __setitem__(self, item, value):
         """Sets value onto this flist by field_name"""
         return self._set_field(item, value)
+
+    def __setattr__(self, name, value):
+        """Sets value onto this flist by field_name"""
+        try:
+            field_number = field_by_identifier(name)
+            return self._set_field(name, value)
+        except KeyError as ex:
+            pass
+        super().__setattr__(name, value)
 
     def _set_field(self, name, value):
         field_number = field_by_identifier(name)
@@ -1225,6 +1241,13 @@ class FList:
             return self._drop_array(item)
         else:
             return self._drop_field(item)
+
+    def __delattr__(self, item):
+        """Deletes the field_name from this flist"""
+        if item in self:
+            return self.__delitem__(item)
+        else:
+            return self.super(item)
 
     def _drop_field(self, name, elem_id=0, optional=0):
         """

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -46,6 +46,7 @@ from pybrm import pin_field_get_name, pin_field_get_type, pin_field_of_name, pin
 from pybrm import constants, pin_conf
 from datetime import datetime
 import unittest
+from unittest.mock import Mock
 from decimal import Decimal
 import sys
 import logging
@@ -2028,8 +2029,8 @@ class TestSearch(TestBrm):
             return 1
 
         def search_build_flist(*args, **kwargs):
-            flist = _search_build_flist(*args, **kwargs)
-            flist.opcode = opcode
+            flist = Mock(_search_build_flist(*args, **kwargs))
+            flist.side_effect = opcode
             return flist
 
         c.search_build_flist = search_build_flist
@@ -2053,8 +2054,8 @@ class TestSearch(TestBrm):
             return {'PIN_FLD_RESULTS': Fake()}
 
         def search_build_flist(*args, **kwargs):
-            flist = _search_build_flist(*args, **kwargs)
-            flist.opcode = opcode
+            flist = Mock(_search_build_flist(*args, **kwargs))
+            flist.side_effect = opcode
             return flist
 
         c.search_build_flist = search_build_flist

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -78,10 +78,12 @@ class TestAddFields(TestBrm):
         self.assertRaises(KeyError, f._set_poid, 'not_real', 'abc')
         self.assertRaises(KeyError, f._set_str, 'not_real', 'abc')
         self.assertRaises(KeyError, f._set_tstamp, 'not_real', 123)
+        self.assertRaises(AttributeError, f.__setattr__, 'not_real', 'abc')
 
     def test_PIN_FLD_POID(self):
         f = self.c.flist()
         self.assertRaises(TypeError, f.__setitem__, 'PIN_FLD_POID', 123)
+        self.assertRaises(TypeError, f.__setattr__, 'PIN_FLD_POID', 123)
         f._set_poid('PIN_FLD_POID', '/event/pybrm')
         s = str(f)
         print(s)
@@ -110,6 +112,30 @@ class TestAddFields(TestBrm):
         self.assertEquals(f['PIN_FLD_POID'].database, 3)
         self.assertRaises(TypeError, f.__setitem__, 'PIN_FLD_POID', ('/account', 2, 100, 3, 5))
 
+    def test_attr_poid_tuple_set(self):
+        f = self.c.flist()
+        f.PIN_FLD_POID = '/account',
+        self.assertEquals(f.PIN_FLD_POID.type, '/account')
+        self.assertEquals(f.PIN_FLD_POID.id, -1)
+        self.assertEquals(f.PIN_FLD_POID.revision, 0)
+        self.assertEquals(f.PIN_FLD_POID.database, 1)
+        f.PIN_FLD_POID = '/account', 2
+        self.assertEquals(f.PIN_FLD_POID.type, '/account')
+        self.assertEquals(f.PIN_FLD_POID.id, 2)
+        self.assertEquals(f.PIN_FLD_POID.revision, 0)
+        self.assertEquals(f.PIN_FLD_POID.database, 1)
+        f.PIN_FLD_POID = '/account', 2, 100
+        self.assertEquals(f.PIN_FLD_POID.type, '/account')
+        self.assertEquals(f.PIN_FLD_POID.id, 2)
+        self.assertEquals(f.PIN_FLD_POID.revision, 100)
+        self.assertEquals(f.PIN_FLD_POID.database, 1)
+        f.PIN_FLD_POID = '/account', 2, 100, 3
+        self.assertEquals(f.PIN_FLD_POID.type, '/account')
+        self.assertEquals(f.PIN_FLD_POID.id, 2)
+        self.assertEquals(f.PIN_FLD_POID.revision, 100)
+        self.assertEquals(f.PIN_FLD_POID.database, 3)
+        self.assertRaises(TypeError, f.__setattr__, 'PIN_FLD_POID', ('/account', 2, 100, 3, 5))
+
     def test_poid_real_poid_string(self):
         f = self.c.flist()
         f['PIN_FLD_POID'] = '0.0.0.1 /account -1 0'
@@ -133,10 +159,35 @@ class TestAddFields(TestBrm):
         self.assertEquals(f['PIN_FLD_POID'].revision, 100)
         self.assertEquals(f['PIN_FLD_POID'].database, 3)
 
+    def test_attr_poid_real_poid_string(self):
+        f = self.c.flist()
+        f.PIN_FLD_POID = '0.0.0.1 /account -1 0'
+        self.assertEquals(f.PIN_FLD_POID.type, '/account')
+        self.assertEquals(f.PIN_FLD_POID.id, -1)
+        self.assertEquals(f.PIN_FLD_POID.revision, 0)
+        self.assertEquals(f.PIN_FLD_POID.database, 1)
+        f.PIN_FLD_POID = '0.0.0.1 /account 2 0'
+        self.assertEquals(f.PIN_FLD_POID.type, '/account')
+        self.assertEquals(f.PIN_FLD_POID.id, 2)
+        self.assertEquals(f.PIN_FLD_POID.revision, 0)
+        self.assertEquals(f.PIN_FLD_POID.database, 1)
+        f.PIN_FLD_POID = '0.0.0.1 /account 2 100'
+        self.assertEquals(f.PIN_FLD_POID.type, '/account')
+        self.assertEquals(f.PIN_FLD_POID.id, 2)
+        self.assertEquals(f.PIN_FLD_POID.revision, 100)
+        self.assertEquals(f.PIN_FLD_POID.database, 1)
+        f.PIN_FLD_POID = '0.0.0.3 /account 2 100'
+        self.assertEquals(f.PIN_FLD_POID.type, '/account')
+        self.assertEquals(f.PIN_FLD_POID.id, 2)
+        self.assertEquals(f.PIN_FLD_POID.revision, 100)
+        self.assertEquals(f.PIN_FLD_POID.database, 3)
+
     def test_poid_real_poid_string_error(self):
         f = self.c.flist()
         self.assertRaises(ValueError, f.__setitem__, 'PIN_FLD_POID', 'abcd /account -1 0')
         self.assertRaises(ValueError, f.__setitem__, 'PIN_FLD_POID', '0.0.0.1 /account abcd 0')
+        self.assertRaises(ValueError, f.__setattr__, 'PIN_FLD_POID', 'abcd /account -1 0')
+        self.assertRaises(ValueError, f.__setattr__, 'PIN_FLD_POID', '0.0.0.1 /account abcd 0')
         # this next one actually doesn't fail, instead it sets revision to 0
         #self.assertRaises(ValueError, f.__setitem__, 'PIN_FLD_POID', '0.0.0.1 /account -1 abcd')
 
@@ -150,6 +201,7 @@ class TestAddFields(TestBrm):
     def test_PIN_FLD_SERVICE_OBJ(self):
         f = self.c.flist()
         self.assertRaises(TypeError, f.__setitem__, 'PIN_FLD_SERVICE_OBJ', 123)
+        self.assertRaises(TypeError, f.__setattr__, 'PIN_FLD_SERVICE_OBJ', 123)
         f._set_poid('PIN_FLD_SERVICE_OBJ', '/service/pybrm')
         s = str(f)
         print(s)
@@ -161,6 +213,16 @@ class TestAddFields(TestBrm):
         self.assertEquals(f['PIN_FLD_CREATED_T'].timestamp(), 1)
         f['PIN_FLD_CREATED_T'] = int(datetime.now().timestamp())
         f['PIN_FLD_CREATED_T'] = datetime.now()
+        s = str(f)
+        print(s)
+
+    def test_attr_PIN_FLD_CREATED_T(self):
+        f = self.c.flist()
+        self.assertRaises(TypeError, f.__setattr__, 'PIN_FLD_CREATED_T', "hello")
+        f.PIN_FLD_CREATED_T = 1.9
+        self.assertEquals(f.PIN_FLD_CREATED_T.timestamp(), 1)
+        f.PIN_FLD_CREATED_T = int(datetime.now().timestamp())
+        f.PIN_FLD_CREATED_T = datetime.now()
         s = str(f)
         print(s)
 
@@ -203,6 +265,13 @@ class TestAddFields(TestBrm):
         f['PIN_FLD_SELECTOR'] = None
         self.assertEqual(f['PIN_FLD_SELECTOR'], None)
 
+    def test_attr_buf(self):
+        f = self.c.flist()
+        f.PIN_FLD_SELECTOR = b'abc'
+        self.assertEqual(f.PIN_FLD_SELECTOR, b'abc')
+        f.PIN_FLD_SELECTOR = None
+        self.assertEqual(f.PIN_FLD_SELECTOR, None)
+
     def test_str_compact(self):
         f = self.c.flist()
         f._set_poid('PIN_FLD_POID', '/event/pybrm')
@@ -221,6 +290,19 @@ class TestAddFields(TestBrm):
         s = str(f)
         print(s)
 
+    def test_attr_PIN_FLD_QUANTITY(self):
+        f = self.c.flist()
+        self.assertRaises(TypeError, f.__setattr__, 'PIN_FLD_QUANTITY', "hello")
+        f.PIN_FLD_QUANTITY = "1.0"
+        f.PIN_FLD_QUANTITY = "1.5"
+        f.PIN_FLD_QUANTITY = 1
+        f.PIN_FLD_QUANTITY = 1.0
+        f.PIN_FLD_QUANTITY = 1.5
+        f.PIN_FLD_QUANTITY = Decimal('1.0')
+        f.PIN_FLD_QUANTITY = Decimal('1.5')
+        s = str(f)
+        print(s)
+
     def test_add(self):
         f = self.c.flist()
         f['PIN_FLD_POID'] = '/a'
@@ -232,6 +314,17 @@ class TestAddFields(TestBrm):
         self.assertNotIn('PIN_FLD_QUANTITY', f)
         self.assertNotIn('PIN_FLD_POID', f2)
 
+    def test_attr_add(self):
+        f = self.c.flist()
+        f.PIN_FLD_POID = '/a'
+        f2 = self.c.flist()
+        f2.PIN_FLD_QUANTITY = 1
+        f3 = f + f2
+        self.assertEquals(f3.PIN_FLD_POID.type, '/a')
+        self.assertEquals(f3.PIN_FLD_QUANTITY, 1)
+        self.assertNotIn('PIN_FLD_QUANTITY', f)
+        self.assertNotIn('PIN_FLD_POID', f2)
+
     def test_concat(self):
         f = self.c.flist()
         f['PIN_FLD_POID'] = '/a'
@@ -240,6 +333,16 @@ class TestAddFields(TestBrm):
         f._concat(f2)
         self.assertEquals(f['PIN_FLD_QUANTITY'], 1)
         self.assertEquals(f['PIN_FLD_POID'].type, '/a')
+        self.assertNotIn('PIN_FLD_POID', f2)
+
+    def test_attr_concat(self):
+        f = self.c.flist()
+        f.PIN_FLD_POID = '/a'
+        f2 = self.c.flist()
+        f2.PIN_FLD_QUANTITY = 1
+        f._concat(f2)
+        self.assertEquals(f.PIN_FLD_QUANTITY, 1)
+        self.assertEquals(f.PIN_FLD_POID.type, '/a')
         self.assertNotIn('PIN_FLD_POID', f2)
 
     def test_concat_and_iterate(self):
@@ -421,6 +524,63 @@ class TestFlist(TestBrm):
         self.assertEqual(flist['PIN_FLD_POID'], None)
 
         del flist['PIN_FLD_POID']
+        self.assertRaises(KeyError, flist.__getitem__, 'PIN_FLD_POID')
+
+        self.assertRaises(BRMError, flist._flist.set_poid, pin_field_of_name('PIN_FLD_POID'), value='foo')
+
+    def test_attr_get_poid(self):
+        flist = self.c.flist()
+        flist.PIN_FLD_POID = '/event/pybrm'
+        poid = flist.PIN_FLD_POID
+        self.assertEqual(poid.database, 1)
+        self.assertEqual(poid.type, '/event/pybrm')
+        self.assertEqual(poid.id, -1)
+        self.assertEqual(poid.revision, 0)
+        flist.PIN_FLD_POID = poid
+        poid = flist.PIN_FLD_POID
+        self.assertEqual(poid.database, 1)
+        self.assertEqual(poid.type, '/event/pybrm')
+        self.assertEqual(poid.id, -1)
+        self.assertEqual(poid.revision, 0)
+
+        poid = Poid(type='/event/pybrm', id=123)
+        flist.PIN_FLD_POID = poid
+        poid = flist.PIN_FLD_POID
+        self.assertEqual(poid.database, 1)
+        self.assertEqual(poid.type, '/event/pybrm')
+        self.assertEqual(poid.id, 123)
+        self.assertEqual(poid.revision, 0)
+        flist.PIN_FLD_POID = poid
+        poid = flist.PIN_FLD_POID
+        self.assertEqual(poid.database, 1)
+        self.assertEqual(poid.type, '/event/pybrm')
+        self.assertEqual(poid.id, 123)
+        self.assertEqual(poid.revision, 0)
+
+        poid = Poid(type='/event/pybrm', id=123, revision=1)
+        flist.PIN_FLD_POID = poid
+        poid = flist.PIN_FLD_POID
+        self.assertEqual(poid.database, 1)
+        self.assertEqual(poid.type, '/event/pybrm')
+        self.assertEqual(poid.id, 123)
+        self.assertEqual(poid.revision, 1)
+        flist.PIN_FLD_POID = poid
+        poid = flist.PIN_FLD_POID
+        self.assertEqual(poid.database, 1)
+        self.assertEqual(poid.type, '/event/pybrm')
+        self.assertEqual(poid.id, 123)
+        self.assertEqual(poid.revision, 1)
+
+        # Test long id
+        poid = Poid(type='/event/pybrm', id=313123319462649664, revision=1)
+        flist.PIN_FLD_POID = poid
+        poid = flist.PIN_FLD_POID
+        self.assertEqual(poid.id, 313123319462649664)
+
+        flist.PIN_FLD_POID = None
+        self.assertEqual(flist.PIN_FLD_POID, None)
+
+        del flist.PIN_FLD_POID
         self.assertRaises(KeyError, flist.__getitem__, 'PIN_FLD_POID')
 
         self.assertRaises(BRMError, flist._flist.set_poid, pin_field_of_name('PIN_FLD_POID'), value='foo')
@@ -1667,6 +1827,15 @@ class TestMisc(TestBrm):
         self.assertEqual(f['PIN_FLD_INHERITED_INFO']['PIN_FLD_POID'].type, 'b')
         self.assertRaises(ValueError, f.__setitem__, 'PIN_FLD_INHERITED_INFO', 'abc')
 
+    def test_attr(self):
+        f = self.c.flist()
+        f.PIN_FLD_POID = 'a'
+        self.assertEqual(f.PIN_FLD_POID.type, 'a')
+        f.PIN_FLD_INHERITED_INFO = {}
+        f.PIN_FLD_INHERITED_INFO.PIN_FLD_POID = 'b'
+        self.assertEqual(f.PIN_FLD_INHERITED_INFO.PIN_FLD_POID.type, 'b')
+        self.assertRaises(ValueError, f.__setattr__, 'PIN_FLD_INHERITED_INFO', 'abc')
+
     def test_list_flist(self):
         f = self.c.flist(['PIN_FLD_POID', 'PIN_FLD_STATUS'])
         self.assertIsNone(f['PIN_FLD_POID'])
@@ -1682,6 +1851,7 @@ class TestMisc(TestBrm):
         f['PIN_FLD_RESULTS'] = [{'PIN_FLD_POID': 'a'}]
         self.assertEqual(f['PIN_FLD_RESULTS'][0]['PIN_FLD_POID'].type, 'a')
         self.assertRaises(TypeError, f.__setitem__, 'PIN_FLD_RESULTS', 'abc')
+        self.assertRaises(TypeError, f.__setattr__, 'PIN_FLD_RESULTS', 'abc')
         f['PIN_FLD_RESULTS'] = {}
         ar = f['PIN_FLD_RESULTS']
         ar[0] = {"PIN_FLD_POID": 'b'}
@@ -1716,6 +1886,27 @@ class TestMisc(TestBrm):
         self.assertEqual(len(f['PIN_FLD_RESULTS']), 2)
         self.assertEqual(f['PIN_FLD_RESULTS'][0]['PIN_FLD_POID'].type, 'zero')
         self.assertEqual(f['PIN_FLD_RESULTS']['*']['PIN_FLD_POID'].type, 'd')
+
+    def test_attr_array(self):
+        f = self.c.flist()
+        f.PIN_FLD_RESULTS = [{'PIN_FLD_POID': 'a'}]
+        self.assertEqual(f.PIN_FLD_RESULTS[0].PIN_FLD_POID.type, 'a')
+        self.assertRaises(TypeError, f.__setattr__, 'PIN_FLD_RESULTS', 'abc')
+        f.PIN_FLD_RESULTS = {}
+        ar = f.PIN_FLD_RESULTS
+        ar[0] = {}
+        ar[0].PIN_FLD_POID = 'b'
+        self.assertEquals(ar[0].PIN_FLD_POID.type, 'b')
+
+        del f.PIN_FLD_RESULTS
+        f.PIN_FLD_RESULTS = []
+        self.assertEqual(len(f), 0)
+        self.assertEqual(len(f.PIN_FLD_RESULTS), 0)
+        del f.PIN_FLD_RESULTS
+        self.assertEqual(len(f), 0)
+        f.PIN_FLD_RESULTS = {}
+        self.assertEqual(len(f), 0)
+        self.assertEqual(len(f.PIN_FLD_RESULTS), 0)
 
     def test_client_misc(self):
         pybrm.pin_err_set_level(1)
@@ -2365,6 +2556,104 @@ class TestVirtualArray(TestBrm):
         del f['PIN_FLD_RESULTS']
         self.assertNotIn(field_num, f._virtual_arrays)
 
+    def test_attr_all(self):
+        field_num = pin_field_of_name('PIN_FLD_RESULTS')
+        f = self.c.flist()
+        self.assertFalse(f._virtual_arrays)
+        self.assertRaises(AttributeError, f.__getattr__, 'PIN_FLD_RESULTS')
+        self.assertFalse(f._virtual_arrays)
+        f.PIN_FLD_RESULTS = {}
+        self.assertIn(field_num, f._virtual_arrays)
+        self.assertIn('PIN_FLD_RESULTS', f)
+        self.assertEqual(len(f.PIN_FLD_RESULTS), 0)
+        self.assertFalse(bool(f.PIN_FLD_RESULTS))
+
+        del f.PIN_FLD_RESULTS
+        self.assertNotIn(field_num, f._virtual_arrays)
+        self.assertFalse(f._virtual_arrays)
+        self.assertRaises(AttributeError, f.__getattr__, 'PIN_FLD_RESULTS')
+
+        f.PIN_FLD_RESULTS = {}
+        self.assertIn(field_num, f._virtual_arrays)
+        self.assertIn('PIN_FLD_RESULTS', f)
+        self.assertEqual(len(f.PIN_FLD_RESULTS), 0)
+        self.assertFalse(bool(f.PIN_FLD_RESULTS))
+
+        f.PIN_FLD_RESULTS[0] = {'PIN_FLD_STATUS': 1}
+        self.assertNotIn(field_num, f._virtual_arrays)
+        self.assertFalse(f._virtual_arrays)
+        del f.PIN_FLD_RESULTS[0]
+        self.assertIn(field_num, f._virtual_arrays)
+
+        f.PIN_FLD_RESULTS[0] = {'PIN_FLD_STATUS': 1}
+        self.assertNotIn(field_num, f._virtual_arrays)
+        self.assertFalse(f._virtual_arrays)
+        f.PIN_FLD_RESULTS[1] = {'PIN_FLD_STATUS': 2}
+        self.assertNotIn(field_num, f._virtual_arrays)
+        self.assertFalse(f._virtual_arrays)
+        del f.PIN_FLD_RESULTS[1]
+        self.assertNotIn(field_num, f._virtual_arrays)
+        self.assertFalse(f._virtual_arrays)
+        del f.PIN_FLD_RESULTS[0]
+        self.assertIn(field_num, f._virtual_arrays)
+        self.assertTrue(f._virtual_arrays)
+
+        f.PIN_FLD_RESULTS[0] = {'PIN_FLD_STATUS': 1}
+        self.assertNotIn(field_num, f._virtual_arrays)
+        self.assertFalse(f._virtual_arrays)
+        f.PIN_FLD_RESULTS.pop(0)
+        self.assertIn(field_num, f._virtual_arrays)
+        self.assertTrue(f._virtual_arrays)
+
+        f.PIN_FLD_RESULTS[0] = {'PIN_FLD_STATUS': 1}
+        self.assertNotIn(field_num, f._virtual_arrays)
+        self.assertFalse(f._virtual_arrays)
+        f.PIN_FLD_RESULTS[1] = {'PIN_FLD_STATUS': 2}
+        self.assertNotIn(field_num, f._virtual_arrays)
+        self.assertFalse(f._virtual_arrays)
+        f.PIN_FLD_RESULTS.clear()
+        self.assertIn(field_num, f._virtual_arrays)
+        self.assertTrue(f._virtual_arrays)
+
+        f = self.c.flist()
+        self.assertIsNone(f.get('PIN_FLD_RESULTS'))
+        f = self.c.flist()
+        f.PIN_FLD_RESULTS = {}
+        self.assertIsNotNone(f.get('PIN_FLD_RESULTS'))
+        f = self.c.flist()
+        f.PIN_FLD_RESULTS = [{'PIN_FLD_POID': 'a'}]
+        self.assertIsNotNone(f.get('PIN_FLD_RESULTS'))
+
+        f = self.c.flist()
+        self.assertRaises(AttributeError, f.__getattr__, 'PIN_FLD_RESULTS')
+        f = self.c.flist()
+        f.PIN_FLD_RESULTS = {}
+        f.PIN_FLD_RESULTS
+        f = self.c.flist()
+        f.PIN_FLD_RESULTS = [{'PIN_FLD_POID': 'a'}]
+        f.PIN_FLD_RESULTS
+
+        f = self.c.flist()
+        f.PIN_FLD_RESULTS = {}
+        self.assertIn(field_num, f._virtual_arrays)
+        f.PIN_FLD_RESULTS = [{'PIN_FLD_POID': 'a'}]
+        self.assertNotIn(field_num, f._virtual_arrays)
+        f.PIN_FLD_RESULTS = {}
+        self.assertIn(field_num, f._virtual_arrays)
+        f.PIN_FLD_RESULTS = {0: {'PIN_FLD_POID': 'a'}}
+        self.assertNotIn(field_num, f._virtual_arrays)
+        f.PIN_FLD_RESULTS = []
+        self.assertIn(field_num, f._virtual_arrays)
+        f.PIN_FLD_RESULTS = None
+        self.assertNotIn(field_num, f._virtual_arrays)
+        f.PIN_FLD_RESULTS = {}
+        self.assertIn(field_num, f._virtual_arrays)
+
+        f = self.c.flist()
+        f.PIN_FLD_RESULTS = {}
+        self.assertIn(field_num, f._virtual_arrays)
+        del f.PIN_FLD_RESULTS
+        self.assertNotIn(field_num, f._virtual_arrays)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Hi Matthew,
You may be glad to know that your library is being used in production at the largest OBRM deployment site in CE. To make it a bit more convenient to use I made some extensions to the code to enable `flist.FIELD` notation which many 'old-timers' prefer. I also added support for field name lookup in interactive shell. I thought you may wish to incorporate these into the official package.
Best,
Tom